### PR TITLE
Changed filenames <script>.log <script>.pid

### DIFF
--- a/daemonize-liquidsoap.sh
+++ b/daemonize-liquidsoap.sh
@@ -39,7 +39,7 @@ cat <<EOS > "${run_script}"
 #!/bin/env liquidsoap
 
 set("log.file",true)
-set("log.file.path","${log_dir}/<script>.log")
+set("log.file.path","${log_dir}/run.log")
 EOS
 
 if [ "${init_type}" != "launchd" ]; then
@@ -49,7 +49,7 @@ set("init.daemon.change_user",true)
 set("init.daemon.change_user.group","${USER}")
 set("init.daemon.change_user.user","${USER}")
 set("init.daemon.pidfile",true)
-set("init.daemon.pidfile.path","${pid_dir}/<script>.pid")
+set("init.daemon.pidfile.path","${pid_dir}/run.pid")
 EOS
 fi;
 


### PR DESCRIPTION
Changed filenames <script>.log <script>.pid to a better name called run.log and run.pid. These are used by:
https://github.com/savonet/liquidsoap-daemon/blob/master/liquidsoap.initd.in