### PR TITLE
s/sh/bash/

### DIFF
--- a/daemonize-liquidsoap.sh
+++ b/daemonize-liquidsoap.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 if [ $# -gt 1 ]; then
   echo "Usage: $0 [script_name]"


### PR DESCRIPTION
so yes, this is probably a bug, but is solved changing interpreter from sh to bash

```
# with sh
$ daemonize-liquidsoap.sh 
/home/liquidsoap/.opam/system/bin/daemonize-liquidsoap.sh: 17: [: /: unexpected operator
/home/liquidsoap/.opam/system/bin/daemonize-liquidsoap.sh: 25: cd: can't cd to /home/liquidsoap/.opam/system/bin//home/liquidsoap/.opam/system/share
cat: liquidsoap.systemd.in: No such file or directory

# with bash
$ daemonize-liquidsoap.sh 
(no output)
```

---

notes

how I installed opam in an updated debian 9 stretch?

`apt install opam` and from there all the dependencies as said in liquidsoap documentation