### PR TITLE
Updated path and user interpolation for logrotate file to fix #26

### DIFF
--- a/daemonize-liquidsoap.sh
+++ b/daemonize-liquidsoap.sh
@@ -133,7 +133,7 @@ cat "liquidsoap.${init_type}.in" | \
 cat "liquidsoap.logrotate.in" | \
     sed -e "s#@log_dir@#${log_dir}#g" | \
     sed -e "s#@pid_dir@#${pid_dir}#g" | \
-    sed -e "s#@USER@#${USER}#g" > "${script_name}-liquidsoap.logrotate"
+    sed -e "s#@user@#${USER}#g" > "${script_name}-liquidsoap.logrotate"
 
 case "${init_type}" in
     launchd)

--- a/daemonize-liquidsoap.sh
+++ b/daemonize-liquidsoap.sh
@@ -131,7 +131,9 @@ cat "liquidsoap.${init_type}.in" | \
     sed -e "s#@pid_file@#${pid_dir}/${script_name}-run.pid#g" > "${script_name}-liquidsoap.${init_type}"
 
 cat "liquidsoap.logrotate.in" | \
-    sed -e "s#@base_dir@#${base_dir}#g" > "${script_name}-liquidsoap.logrotate"
+    sed -e "s#@log_dir@#${log_dir}#g" | \
+    sed -e "s#@pid_dir@#${pid_dir}#g" | \
+    sed -e "s#@USER@#${USER}#g" > "${script_name}-liquidsoap.logrotate"
 
 case "${init_type}" in
     launchd)

--- a/liquidsoap.logrotate.in
+++ b/liquidsoap.logrotate.in
@@ -1,5 +1,5 @@
 @log_dir@/*.log {
-  su @USER@ @USER@
+  su @user@ @user@
   compress
   rotate 5
   size 300k

--- a/liquidsoap.logrotate.in
+++ b/liquidsoap.logrotate.in
@@ -1,4 +1,5 @@
-@base_dir@/log/liquidsoap/*.log {
+@log_dir@/*.log {
+  su @USER@ @USER@
   compress
   rotate 5
   size 300k
@@ -6,8 +7,8 @@
   notifempty
   sharedscripts
   postrotate
-    for liq in @base_dir@/run/liquidsoap/*.pid ; do
-      if test $liq != '@base_dir@/run/liquidsoap/*.pid' ; then
+    for liq in @pid_dir@/*.pid ; do
+      if test $liq != '@pid_dir@/*.pid' ; then
         start-stop-daemon --stop --signal USR1 --quiet --pidfile $liq
       fi
     done


### PR DESCRIPTION
Some changes to the path and user interpolation for the logrotate file generation to fix the issues reported in https://github.com/savonet/liquidsoap-daemon/issues/26 

Using the `log_dir` and `pid_dir` variables to set those directories instead of the current `base_dir` plus constant folder names.

Also added `su user user` so that logrotate runs as the user who owns the folder where the logs are located instead of the root user, which prevents logrotate failing due to a security warning.

Tested with logrotate 3.11.0 in Ubuntu 18.04.04 server