### PR TITLE
Update liquidsoap.systemd.in

### DIFF
--- a/liquidsoap.systemd.in
+++ b/liquidsoap.systemd.in
@@ -1,7 +1,7 @@
 [Unit]
 Description=@script_name@ Liquidsoap daemon
 After=network.target
-Documentation=http://liquidsoap.fm/
+Documentation=http://liquidsoap.info/
 
 [Service]
 Type=forking


### PR DESCRIPTION
Changed the documentation URL since the `.fm` domain doesn't point to the official website anymore.